### PR TITLE
Fix the accept/reject button on the request detail page

### DIFF
--- a/http-proxy-policy/policy/admin.py
+++ b/http-proxy-policy/policy/admin.py
@@ -202,7 +202,7 @@ class RequestAdmin(admin.ModelAdmin):
         return redirect(request.META.get("HTTP_REFERER", "/"))
 
     def accept_proxy_request(self, request, pk):
-        self.process_proxy_request(request, pk, models.Verdict.ACCEPT)
+        return self.process_proxy_request(request, pk, models.Verdict.ACCEPT)
 
     def reject_proxy_request(self, request, pk):
-        self.process_proxy_request(request, pk, models.Verdict.REJECT)
+        return self.process_proxy_request(request, pk, models.Verdict.REJECT)

--- a/squid-forward-proxy-operator/src/charm.py
+++ b/squid-forward-proxy-operator/src/charm.py
@@ -53,7 +53,6 @@ class SquidProxyCharm(ops.CharmBase):
         self.framework.observe(self.on[PEER_INTEGRATION_NAME].relation_joined, self._reconcile)
         self.framework.observe(self.on.secret_changed, self._reconcile)
         self.framework.observe(self.on.update_status, self._reconcile)
-        self.unit.open_port("tcp", 3128)
 
     def _install(self, _: ops.EventBase) -> None:
         """Install Squid."""
@@ -63,6 +62,7 @@ class SquidProxyCharm(ops.CharmBase):
 
     def _reconcile(self, _: ops.EventBase) -> None:
         """Run the main reconciliation loop."""
+        self.unit.set_ports(ops.Port(protocol="tcp", port=self._get_http_port()))
         peer_integration = self.model.get_relation(relation_name=PEER_INTEGRATION_NAME)
         if not peer_integration:
             self.unit.status = ops.WaitingStatus("waiting for peer integration")


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Fix the accept/reject button on the request detail page. Also, match the Squid exported port with the http-port charm configuration.

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `senior-review-required`, `documentation`)
- [x] The `docs/changelog.md` is updated with user-relevant changes.

<!-- Explanation for any unchecked items above -->
