### PR TITLE
Convert `http_proxy.py` into a CharmHub library

### DIFF
--- a/http-proxy-policy-operator/docs/changelog.md
+++ b/http-proxy-policy-operator/docs/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2025-09-26
+
+### Updated
+
+- Converted the `http-proxy` module into a CharmHub library.
+
 ## 2025-08-25
 
 ### Updated

--- a/http-proxy-policy-operator/lib/charms/squid_forward_proxy/v0/http_proxy.py
+++ b/http-proxy-policy-operator/lib/charms/squid_forward_proxy/v0/http_proxy.py
@@ -1,9 +1,7 @@
 # Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-# pylint: disable=too-many-lines
-
-r"""Library to manage the http-proxy relation.
+"""Library to manage the http-proxy relation.
 
 This library contains the Requirer and Provider classes for handling the
 http-proxy interface.
@@ -171,8 +169,17 @@ class FooCharm:
                 https_proxy="https://proxy.test",
                 user=None,
             )
+"""
 
-"""  # noqa: D214,D405,D410,D411,D416
+# The unique Charmhub library identifier, never change it
+LIBID = "0dd2d8435fad41ce9a4bcdbda4d9a22d"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 1
 
 import copy
 import ipaddress

--- a/http-proxy-policy-operator/src/charm.py
+++ b/http-proxy-policy-operator/src/charm.py
@@ -15,10 +15,10 @@ from typing import Any, cast
 import ops
 from charms.data_platform_libs.v0.data_interfaces import DatabaseRequires
 from charms.squid_forward_proxy.v0 import http_proxy
+from charms.squid_forward_proxy.v0.http_proxy import DEFAULT_HTTP_PROXY_INTEGRATION_NAME
 
 import policy
 import relay
-from http_proxy import DEFAULT_HTTP_PROXY_INTEGRATION_NAME
 
 logger = logging.getLogger(__name__)
 

--- a/http-proxy-policy-operator/src/charm.py
+++ b/http-proxy-policy-operator/src/charm.py
@@ -14,8 +14,8 @@ from typing import Any, cast
 
 import ops
 from charms.data_platform_libs.v0.data_interfaces import DatabaseRequires
+from charms.squid_forward_proxy.v0 import http_proxy
 
-import http_proxy
 import policy
 import relay
 from http_proxy import DEFAULT_HTTP_PROXY_INTEGRATION_NAME

--- a/http-proxy-policy-operator/src/policy.py
+++ b/http-proxy-policy-operator/src/policy.py
@@ -10,8 +10,8 @@ from typing import Optional
 
 import requests
 from charms.operator_libs_linux.v2 import snap
+from charms.squid_forward_proxy.v0 import http_proxy
 
-import http_proxy
 import timer
 
 

--- a/http-proxy-policy-operator/src/relay.py
+++ b/http-proxy-policy-operator/src/relay.py
@@ -6,8 +6,8 @@ import dataclasses
 import logging
 
 import ops
+from charms.squid_forward_proxy.v0 import http_proxy
 
-import http_proxy
 import policy
 
 logger = logging.getLogger(__name__)

--- a/http-proxy-policy-operator/tests/integration/any_charm.py
+++ b/http-proxy-policy-operator/tests/integration/any_charm.py
@@ -1,10 +1,12 @@
 # Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+# pylint: disable=import-error
+
 """Integration test charm."""
 
 import http_proxy
-from any_charm_base import AnyCharmBase  # pylint: disable=import-error
+from any_charm_base import AnyCharmBase
 
 
 class AnyCharm(AnyCharmBase):  # pylint: disable=too-few-public-methods

--- a/http-proxy-policy-operator/tests/integration/any_charm.py
+++ b/http-proxy-policy-operator/tests/integration/any_charm.py
@@ -4,8 +4,7 @@
 """Integration test charm."""
 
 from any_charm_base import AnyCharmBase  # pylint: disable=import-error
-
-import http_proxy
+from charms.squid_forward_proxy.v0 import http_proxy
 
 
 class AnyCharm(AnyCharmBase):  # pylint: disable=too-few-public-methods

--- a/http-proxy-policy-operator/tests/integration/any_charm.py
+++ b/http-proxy-policy-operator/tests/integration/any_charm.py
@@ -3,8 +3,8 @@
 
 """Integration test charm."""
 
+import http_proxy
 from any_charm_base import AnyCharmBase  # pylint: disable=import-error
-from charms.squid_forward_proxy.v0 import http_proxy
 
 
 class AnyCharm(AnyCharmBase):  # pylint: disable=too-few-public-methods

--- a/http-proxy-policy-operator/tests/integration/conftest.py
+++ b/http-proxy-policy-operator/tests/integration/conftest.py
@@ -39,7 +39,8 @@ async def http_proxy_policy_fixture(
                 {
                     "any_charm.py": (pathlib.Path(__file__).parent / "any_charm.py").read_text(),
                     "http_proxy.py": (
-                        pathlib.Path(__file__).parent.parent.parent / "src/http_proxy.py"
+                        pathlib.Path(__file__).parent.parent.parent
+                        / "lib/charms/squid_forward_proxy/v0/http_proxy.py"
                     ).read_text(),
                 }
             ),

--- a/http-proxy-policy-operator/tests/integration/conftest.py
+++ b/http-proxy-policy-operator/tests/integration/conftest.py
@@ -77,7 +77,10 @@ class RequirerCharm:
             / "squid-forward-proxy-operator/tests/integration/any_charm.py"
         )
         any_charm_py_content = any_charm_py.read_text(encoding="utf-8")
-        http_proxy_py = pathlib.Path(__file__).parent.parent.parent / "src/http_proxy.py"
+        http_proxy_py = (
+            pathlib.Path(__file__).parent.parent.parent
+            / "lib/charms/squid_forward_proxy/v0/http_proxy.py"
+        )
         http_proxy_py_content = http_proxy_py.read_text(encoding="utf-8")
         self._app = await self._model.deploy(
             "any-charm",

--- a/http-proxy-policy-operator/tests/integration/test_charm.py
+++ b/http-proxy-policy-operator/tests/integration/test_charm.py
@@ -7,7 +7,7 @@
 
 import logging
 
-import http_proxy
+from charms.squid_forward_proxy.v0 import http_proxy
 
 logger = logging.getLogger(__name__)
 

--- a/http-proxy-policy-operator/tests/unit/test_charm.py
+++ b/http-proxy-policy-operator/tests/unit/test_charm.py
@@ -11,8 +11,8 @@ import uuid
 from typing import cast
 
 import ops.testing
+from charms.squid_forward_proxy.v0 import http_proxy
 
-import http_proxy
 import policy
 from charm import HttpProxyPolicyCharm
 

--- a/http-proxy-policy/docs/changelog.md
+++ b/http-proxy-policy/docs/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2025-09-26
+
+### Updated
+
+- Converted the `http-proxy` module into a CharmHub library.
+
 ## 2025-08-25
 
 ### Updated

--- a/squid-forward-proxy-operator/lib/charms/squid_forward_proxy/v0/http_proxy.py
+++ b/squid-forward-proxy-operator/lib/charms/squid_forward_proxy/v0/http_proxy.py
@@ -1,9 +1,7 @@
 # Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-# pylint: disable=too-many-lines
-
-r"""Library to manage the http-proxy relation.
+"""Library to manage the http-proxy relation.
 
 This library contains the Requirer and Provider classes for handling the
 http-proxy interface.
@@ -171,8 +169,17 @@ class FooCharm:
                 https_proxy="https://proxy.test",
                 user=None,
             )
+"""
 
-"""  # noqa: D214,D405,D410,D411,D416
+# The unique Charmhub library identifier, never change it
+LIBID = "0dd2d8435fad41ce9a4bcdbda4d9a22d"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 1
 
 import copy
 import ipaddress

--- a/squid-forward-proxy-operator/src/charm.py
+++ b/squid-forward-proxy-operator/src/charm.py
@@ -12,10 +12,10 @@ import typing
 
 import ops
 from charms.grafana_agent.v0 import cos_agent
+from charms.squid_forward_proxy.v0 import http_proxy
+from charms.squid_forward_proxy.v0.http_proxy import DEFAULT_HTTP_PROXY_INTEGRATION_NAME
 
-import http_proxy
 import squid
-from http_proxy import DEFAULT_HTTP_PROXY_INTEGRATION_NAME
 
 logger = logging.getLogger(__name__)
 
@@ -378,4 +378,5 @@ class IntegrationReconciler:  # pylint: disable=too-few-public-methods,too-many-
 
 
 if __name__ == "__main__":  # pragma: nocover
+    ops.main.main(SquidProxyCharm)
     ops.main.main(SquidProxyCharm)

--- a/squid-forward-proxy-operator/src/charm.py
+++ b/squid-forward-proxy-operator/src/charm.py
@@ -379,4 +379,3 @@ class IntegrationReconciler:  # pylint: disable=too-few-public-methods,too-many-
 
 if __name__ == "__main__":  # pragma: nocover
     ops.main.main(SquidProxyCharm)
-    ops.main.main(SquidProxyCharm)

--- a/squid-forward-proxy-operator/src/squid.py
+++ b/squid-forward-proxy-operator/src/squid.py
@@ -14,8 +14,7 @@ from collections import defaultdict
 
 from charms.operator_libs_linux.v0 import apt
 from charms.operator_libs_linux.v1 import systemd
-
-from http_proxy import (
+from charms.squid_forward_proxy.v0.http_proxy import (
     AUTH_METHOD_SRCIP,
     AUTH_METHOD_USERPASS,
     HttpProxySpec,

--- a/squid-forward-proxy-operator/tests/integration/any_charm.py
+++ b/squid-forward-proxy-operator/tests/integration/any_charm.py
@@ -7,8 +7,7 @@ import re
 
 import requests
 from any_charm_base import AnyCharmBase, logger  # pylint: disable=import-error
-
-import http_proxy
+from charms.squid_forward_proxy.v0 import http_proxy
 
 
 class AnyCharm(AnyCharmBase):

--- a/squid-forward-proxy-operator/tests/integration/any_charm.py
+++ b/squid-forward-proxy-operator/tests/integration/any_charm.py
@@ -5,9 +5,9 @@
 
 import re
 
+import http_proxy
 import requests
 from any_charm_base import AnyCharmBase, logger  # pylint: disable=import-error
-from charms.squid_forward_proxy.v0 import http_proxy
 
 
 class AnyCharm(AnyCharmBase):

--- a/squid-forward-proxy-operator/tests/integration/any_charm.py
+++ b/squid-forward-proxy-operator/tests/integration/any_charm.py
@@ -1,13 +1,15 @@
 # Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+# pylint: disable=import-error
+
 """Integration test charm."""
 
 import re
 
 import http_proxy
 import requests
-from any_charm_base import AnyCharmBase, logger  # pylint: disable=import-error
+from any_charm_base import AnyCharmBase, logger
 
 
 class AnyCharm(AnyCharmBase):

--- a/squid-forward-proxy-operator/tests/integration/conftest.py
+++ b/squid-forward-proxy-operator/tests/integration/conftest.py
@@ -47,7 +47,10 @@ class AnyCharm:
         """Deploy the any-charm in the testing model."""
         any_charm_py = pathlib.Path(__file__).parent / "any_charm.py"
         any_charm_py_content = any_charm_py.read_text(encoding="utf-8")
-        http_proxy_py = pathlib.Path(__file__).parent.parent.parent / "src/http_proxy.py"
+        http_proxy_py = (
+            pathlib.Path(__file__).parent.parent.parent
+            / "lib/charms/squid_forward_proxy/v0/http_proxy.py"
+        )
         http_proxy_py_content = http_proxy_py.read_text(encoding="utf-8")
         self._app = await self._model.deploy(
             "any-charm",

--- a/squid-forward-proxy-operator/tests/integration/test_charm.py
+++ b/squid-forward-proxy-operator/tests/integration/test_charm.py
@@ -9,8 +9,7 @@ import logging
 
 import pytest
 import requests
-
-import http_proxy
+from charms.squid_forward_proxy.v0 import http_proxy
 
 logger = logging.getLogger(__name__)
 

--- a/squid-forward-proxy-operator/tests/unit/test_charm.py
+++ b/squid-forward-proxy-operator/tests/unit/test_charm.py
@@ -12,8 +12,8 @@ import typing
 import uuid
 
 import ops.testing
+from charms.squid_forward_proxy.v0 import http_proxy
 
-import http_proxy
 import squid
 from charm import SquidProxyCharm
 

--- a/squid-forward-proxy-operator/tests/unit/test_http_proxy.py
+++ b/squid-forward-proxy-operator/tests/unit/test_http_proxy.py
@@ -10,8 +10,7 @@ import uuid
 
 import pydantic
 import pytest
-
-import http_proxy
+from charms.squid_forward_proxy.v0 import http_proxy
 
 
 class PureHttpProxyRequestListReader(http_proxy._HttpProxyRequestListReader):


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
Convert `http_proxy.py` into a CharmHub library. Will publish it once this PR is merged.

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `senior-review-required`, `documentation`)
- [x] The appropriate `docs/changelog.md` is updated with user-relevant changes.

<!-- Explanation for any unchecked items above -->
