### PR TITLE
fix link in docstring

### DIFF
--- a/squid-forward-proxy-operator/lib/charms/squid_forward_proxy/v0/http_proxy.py
+++ b/squid-forward-proxy-operator/lib/charms/squid_forward_proxy/v0/http_proxy.py
@@ -119,8 +119,7 @@ refer to the implementation in [http-proxy-policy-operator]. This class is for m
 cases where developers want to issue multiple requests with different parameters.
 
 [http-proxy-policy-operator]:
-    https://github.com/canonical/http-proxy-operators/blob/main/
-    http-proxy-policy-operator/src/charm.py
+    https://github.com/canonical/http-proxy-operators/blob/main/http-proxy-policy-operator/src/charm.py
 
 
 ### Using library as a provider


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
CharmHub is not rendering the link properly. Initially i broke it down since i assumed linter will complain but it doesn't seem to complain.

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `senior-review-required`, `documentation`)
- [ ] The appropriate `docs/changelog.md` is updated with user-relevant changes.

<!-- Explanation for any unchecked items above -->
