### PR TITLE
Disable jubilant logging for juju.deploy, juju.config and juju.exec

### DIFF
--- a/http-proxy-configurator-operator/tests/integration/conftest.py
+++ b/http-proxy-configurator-operator/tests/integration/conftest.py
@@ -67,11 +67,7 @@ def application_fixture(pytestconfig: pytest.Config, juju: jubilant.Juju, charm:
     if pytestconfig.getoption("--use-existing") and app_name in juju.status().apps:
         yield app_name
         return
-    juju.deploy(
-        charm=charm,
-        app=app_name,
-        base="ubuntu@24.04",
-    )
+    juju.deploy(charm=charm, app=app_name, base="ubuntu@24.04", log=False)
     yield app_name
 
 
@@ -94,6 +90,7 @@ def squid_proxy_fixture(pytestconfig: pytest.Config, juju: jubilant.Juju):
         channel="latest/edge",
         revision=22,
         base="ubuntu@24.04",
+        log=False,
     )
     juju.wait(
         lambda status: jubilant.all_active(status, SQUID_PROXY_APP),
@@ -120,5 +117,6 @@ def http_proxy_requirer_fixture(pytestconfig: pytest.Config, juju: jubilant.Juju
         app=REQUIRER_APP,
         base="ubuntu@24.04",
         config={"http-proxy-domains": "ignored"},
+        log=False,
     )
     yield REQUIRER_APP

--- a/http-proxy-configurator-operator/tests/integration/test_charm.py
+++ b/http-proxy-configurator-operator/tests/integration/test_charm.py
@@ -28,6 +28,7 @@ def test_config_hostnames_and_paths(
         values={
             "http-proxy-domains": "canonical.com",
         },
+        log=False,
     )
     juju.wait(
         lambda status: jubilant.all_active(status, squid_proxy, application),
@@ -47,6 +48,7 @@ def test_config_hostnames_and_paths(
     juju.config(
         app=application,
         values={"http-proxy-domains": "canonical.com", "http-proxy-auth": "srcip"},
+        log=False,
     )
     juju.wait(
         lambda status: jubilant.all_active(status, squid_proxy, application, http_proxy_requirer),


### PR DESCRIPTION
Add log=False to all juju.deploy(), juju.config() and juju.exec() calls in integration tests.