### PR TITLE
chore(ci): add actions:read and contents:write permissions to publish workflows (charmkeeper)

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -4,13 +4,16 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - main
+    - main
 
 jobs:
   publish-charms:
     strategy:
       matrix:
-        charm: [ squid-forward-proxy, http-proxy-policy, http-proxy-configurator]
+        charm: [squid-forward-proxy, http-proxy-policy, http-proxy-configurator]
+    permissions:
+      actions: read
+      contents: write
     uses: canonical/operator-workflows/.github/workflows/publish_charm.yaml@main
     secrets: inherit
     with:
@@ -22,31 +25,31 @@ jobs:
   publish-snap:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+    - uses: actions/checkout@v6
 
-      - name: Change directory
-        run: |
-          TEMP_DIR=$(mktemp -d)
-          cp -rp ./http-proxy-policy/. $TEMP_DIR
-          rm -rf .* * || :
-          cp -rp $TEMP_DIR/. .
-          rm -rf $TEMP_DIR
-          ls -lah
+    - name: Change directory
+      run: |
+        TEMP_DIR=$(mktemp -d)
+        cp -rp ./http-proxy-policy/. $TEMP_DIR
+        rm -rf .* * || :
+        cp -rp $TEMP_DIR/. .
+        rm -rf $TEMP_DIR
+        ls -lah
 
-      - name: Build Snap
-        id: snapcraft-build
-        uses: snapcore/action-build@v1
+    - name: Build Snap
+      id: snapcraft-build
+      uses: snapcore/action-build@v1
 
-      - uses: actions/upload-artifact@v5
-        with:
-          name: charmed-http-proxy-policy-snap
-          path: "*.snap"
+    - uses: actions/upload-artifact@v5
+      with:
+        name: charmed-http-proxy-policy-snap
+        path: "*.snap"
 
-      - name: Publish Snap
-        env:
-          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPSTORE_TOKEN }}
-        run: |
-          for snap in *.snap
-          do
-            snapcraft upload $snap --release edge
-          done
+    - name: Publish Snap
+      env:
+        SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPSTORE_TOKEN }}
+      run: |
+        for snap in *.snap
+        do
+          snapcraft upload $snap --release edge
+        done


### PR DESCRIPTION
This PR adds `actions: read` and `contents: write` permissions to GitHub Actions jobs that use the `canonical/operator-workflows/.github/workflows/publish_charm.yaml` reusable workflow or `canonical/charming-actions/upload-charm` action.
These permissions are required for the workflow to function correctly with the latest changes to the reusable workflow.